### PR TITLE
将active_keywords部分移到配置文件里面

### DIFF
--- a/conf/user.conf.example
+++ b/conf/user.conf.example
@@ -35,6 +35,9 @@ SOCKET_ROOM_ID=3
 # 统一活动抽奖
 USE_ACTIVE=true
 
+# 启用的抽奖功能(使用|分隔)
+ACTIVE_KEYWORDS=摩天大楼|小电视飞船|小金人
+
 # 银瓜子兑换硬币
 USE_SILVER2COIN=true
 

--- a/src/DataTreating.php
+++ b/src/DataTreating.php
@@ -113,7 +113,7 @@ class DataTreating
                 }
 
                 // TODO 活动抽奖 暂定每期修改
-                foreach (self::$active_keywords as $value) {
+                foreach ($active_keywords as $value) {
                     if (strpos($resp['msg'], $value) !== false) {
                         return [
                             'type' => 'active',
@@ -128,7 +128,7 @@ class DataTreating
                  * 系统消息, 广播
                  */
                 // TODO 小电视|摩天大楼|C位光环|盛夏么么茶统一
-                foreach (self::$active_keywords as $value) {
+                foreach ($active_keywords as $value) {
                     if (strpos($resp['msg'], $value) !== false) {
                         return [
                             'type' => 'active',

--- a/src/DataTreating.php
+++ b/src/DataTreating.php
@@ -18,12 +18,6 @@ class DataTreating
 {
     // STORM KEY
     protected static $storm_keyword = '节奏风暴';
-    // ACTIVE KEY
-    protected static $active_keywords = [
-        '摩天大楼',
-        '小电视飞船',
-        '小金人',
-    ];
 
     // PARSE ARRAY
     public static function socketArrayToDispose(array $data)
@@ -53,6 +47,14 @@ class DataTreating
         }
 
         $resp = json_decode($resp, true);
+
+        if (empty(getenv('ACTIVE_KEYWORDS'))) {
+            Log::error('未设置ACTIVE_KEYWORDS! 请参考新版配置文件');
+            die();
+        }
+
+        // ACTIVE KEY
+        $active_keywords = explode('|', getenv('ACTIVE_KEYWORDS'));
 
         switch ($resp['cmd']) {
             case 'DANMU_MSG':


### PR DESCRIPTION
这样即可以手动控制某些抽奖功能不打开（比如小电视飞船），
又能在有新活动的时候，直接在配置文件添加新的抽奖（比如小金人）。